### PR TITLE
UI tweaks

### DIFF
--- a/data/ui/card.ui
+++ b/data/ui/card.ui
@@ -10,7 +10,7 @@
           <object class="GtkImage" id="view_image">
             <property name="visible">false</property>
             <property name="icon-name">view-reveal-symbolic</property>
-            <property name="tooltip-text" translatable="true">Note is open</property>
+            <property name="tooltip-text" translatable="true">Note is Open</property>
             <style>
               <class name="dim-label"/>
             </style>
@@ -36,7 +36,7 @@
         <child>
           <object class="GtkButton" id="delete_button">
             <property name="icon-name">user-trash-symbolic</property>
-            <property name="tooltip-text" translatable="true">Delete note</property>
+            <property name="tooltip-text" translatable="true">Delete Note</property>
             <style>
               <class name="flat"/>
             </style>

--- a/data/ui/notes.ui
+++ b/data/ui/notes.ui
@@ -67,12 +67,13 @@
                     <property name="vexpand">true</property>
                     <property name="visible">false</property>
                     <property name="icon-name">document-edit-symbolic</property>
-                    <property name="title" translatable="true">No notes</property>
+                    <property name="title" translatable="true">No Notes</property>
                     <property name="description" translatable="true">After you create notes, they will appear here</property>
                     <child>
                       <object class="GtkButton">
                         <property name="halign">center</property>
-                        <property name="label" translatable="true">Create a new note</property>
+                        <property name="label" translatable="true">_New Note</property>
+                        <property name="use-underline">true</property>
                         <property name="action-name">app.new-note</property>
                         <style>
                           <class name="pill"/>

--- a/data/ui/notes.ui
+++ b/data/ui/notes.ui
@@ -26,6 +26,8 @@
                 <property name="receives-default">false</property>
                 <property name="icon-name">open-menu-symbolic</property>
                 <property name="menu-model">primaryMenu</property>
+                <property name="tooltip-text" translatable="yes">Main Menu</property>
+                <property name="primary">true</property>
               </object>
             </child>
             <property name="title-widget">

--- a/data/ui/notes.ui
+++ b/data/ui/notes.ui
@@ -121,7 +121,7 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="true">Keyboard shortcuts</attribute>
+        <attribute name="label" translatable="true">Keyboard Shortcuts</attribute>
         <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>

--- a/data/ui/notes.ui
+++ b/data/ui/notes.ui
@@ -56,7 +56,7 @@
                     </style>
                     <child>
                       <object class="GtkSearchEntry" id="search_entry">
-                        <property name="placeholder-text" translatable="true">Search...</property>
+                        <property name="placeholder-text" translatable="true">Search notes…</property>
                         <property name="hexpand">true</property>
                       </object>
                     </child>

--- a/data/ui/notes.ui
+++ b/data/ui/notes.ui
@@ -18,7 +18,7 @@
                 <property name="receives-default">false</property>
                 <property name="icon-name">list-add-symbolic</property>
                 <property name="action-name">app.new-note</property>
-                <property name="tooltip-text" translatable="true">Create a new note</property>
+                <property name="tooltip-text" translatable="true">New Note</property>
               </object>
             </child>
             <child type="end">

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -25,6 +25,8 @@
               <object class="GtkMenuButton" id="menu_button">
                 <property name="icon-name">open-menu-symbolic</property>
                 <property name="menu-model">app_menu</property>
+                <property name="tooltip-text" translatable="yes">Main Menu</property>
+                <property name="primary">true</property>
               </object>
             </child>
             <property name="title-widget">

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -18,7 +18,7 @@
               <object class="GtkButton">
                 <property name="icon-name">list-add-symbolic</property>
                 <property name="action-name">app.new-note</property>
-                <property name="tooltip-text" translatable="yes">Create a new note</property>
+                <property name="tooltip-text" translatable="yes">New Note</property>
               </object>
             </child>
             <child type="end">


### PR DESCRIPTION
**general: Improve tooltips**

- Use header capitalization
- Make tooltips shorter

**general: Main Menu tweaks**

- Allow opening the Main Menu with F10
- Add tooltip to the Main Menu button (HIG advises that all controls in the headerbar must have a tooltip)

**notes: Improve AdwStatusPage**

- Use header capitalization when applicable
- Add mnemonic to the button
- Shorten the button label

**notes: Use header capitalization in menu items**

**notes: Improve the placeholder text used in the search entry**

- Change the placeholder text to be descriptive and to indicate that notes will be searched
- Switch the tree dots to an ellipsis char

References:
- https://developer.gnome.org/hig/guidelines/writing-style.html
- https://developer.gnome.org/hig/patterns/feedback/tooltips.html
- https://developer.gnome.org/hig/patterns/controls/buttons.html
- https://developer.gnome.org/hig/patterns/controls/text-fields.html
- https://developer.gnome.org/hig/patterns/feedback/placeholders.html