### PR TITLE
Add problem matcher for `appstream-util validate`'s output

### DIFF
--- a/.github/matchers/appstream-util-validation.json
+++ b/.github/matchers/appstream-util-validation.json
@@ -1,0 +1,19 @@
+{
+    "problemMatcher": [
+        {
+            "owner": "appstream-validation",
+            "pattern": [
+                {
+                    "regexp": "^(.*\\.(appdata|metainfo)\\.(x|y)ml): FAILED:$",
+                    "file": 1
+                },
+                {
+                    "regexp": "^.\\s+(\\w+-invalid|\\w+-missing|tag-duplicated|translations-required|duplicate-data|url-not-found)\\s+:\\s+(.*)$",
+                    "code": 1,
+                    "message": 2,
+                    "loop": true
+                }
+            ]
+        }
+    ]
+}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,7 @@ jobs:
     - uses: actions/checkout@v3
       with:
         persist-credentials: false
+    - run: echo "::add-matcher::.github/matchers/appstream-util-validation.json"
     - uses: flatpak/flatpak-github-actions/flatpak-builder@v6.1
       with:
         bundle: sticky.flatpak

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,5 +26,6 @@ jobs:
         bundle: sticky.flatpak
         manifest-path: com.vixalien.sticky.json
         cache-key: flatpak-builder-${{ github.sha }}
+        run-tests: true
         cache: true
         restore-cache: true


### PR DESCRIPTION
See https://github.com/vixalien/sticky/issues/59#issuecomment-1554644759

I'm still trying to figure out how to also annotate the filename, hence made this a draft.