### PR TITLE
UI: Mark translatable strings yes

### DIFF
--- a/data/ui/card.ui
+++ b/data/ui/card.ui
@@ -10,7 +10,7 @@
           <object class="GtkImage" id="view_image">
             <property name="visible">false</property>
             <property name="icon-name">view-reveal-symbolic</property>
-            <property name="tooltip-text" translatable="true">Note is Open</property>
+            <property name="tooltip-text" translatable="yes">Note is Open</property>
             <style>
               <class name="dim-label"/>
             </style>
@@ -36,7 +36,7 @@
         <child>
           <object class="GtkButton" id="delete_button">
             <property name="icon-name">user-trash-symbolic</property>
-            <property name="tooltip-text" translatable="true">Delete Note</property>
+            <property name="tooltip-text" translatable="yes">Delete Note</property>
             <style>
               <class name="flat"/>
             </style>

--- a/data/ui/notes.ui
+++ b/data/ui/notes.ui
@@ -15,7 +15,7 @@
                 <property name="receives-default">false</property>
                 <property name="icon-name">list-add-symbolic</property>
                 <property name="action-name">app.new-note</property>
-                <property name="tooltip-text" translatable="true">New Note</property>
+                <property name="tooltip-text" translatable="yes">New Note</property>
               </object>
             </child>
             <child type="end">
@@ -23,13 +23,13 @@
                 <property name="receives-default">false</property>
                 <property name="icon-name">open-menu-symbolic</property>
                 <property name="menu-model">primaryMenu</property>
-                <property name="tooltip-text" translatable="true">Main Menu</property>
+                <property name="tooltip-text" translatable="yes">Main Menu</property>
                 <property name="primary">true</property>
               </object>
             </child>
             <property name="title-widget">
               <object class="AdwWindowTitle">
-                <property name="title" translatable="true">Sticky Notes</property>
+                <property name="title" translatable="yes">Sticky Notes</property>
               </object>
             </property>
             <style>
@@ -56,7 +56,7 @@
                         </style>
                         <child>
                           <object class="GtkSearchEntry" id="search_entry">
-                            <property name="placeholder-text" translatable="true">Search notes…</property>
+                            <property name="placeholder-text" translatable="yes">Search notes…</property>
                             <property name="hexpand">true</property>
                           </object>
                         </child>
@@ -69,12 +69,12 @@
                           <object class="AdwStatusPage" id="no_notes">
                             <property name="vexpand">true</property>
                             <property name="icon-name">com.vixalien.sticky-symbolic</property>
-                            <property name="title" translatable="true">No Notes</property>
-                            <property name="description" translatable="true">After you create notes, they will appear here</property>
+                            <property name="title" translatable="yes">No Notes</property>
+                            <property name="description" translatable="yes">After you create notes, they will appear here</property>
                             <child>
                               <object class="GtkButton">
                                 <property name="halign">3</property>
-                                <property name="label" translatable="true">_New Note</property>
+                                <property name="label" translatable="yes">_New Note</property>
                                 <property name="use-underline">true</property>
                                 <property name="action-name">app.new-note</property>
                                 <style>
@@ -89,8 +89,8 @@
                           <object class="AdwStatusPage" id="no_results">
                             <property name="vexpand">true</property>
                             <property name="icon-name">system-search-symbolic</property>
-                            <property name="title" translatable="true">No Results</property>
-                            <property name="description" translatable="true">Try a different search</property>
+                            <property name="title" translatable="yes">No Results</property>
+                            <property name="description" translatable="yes">Try a different search</property>
                           </object>
                         </child>
                         <child>
@@ -122,17 +122,17 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="true">Keyboard Shortcuts</attribute>
+        <attribute name="label" translatable="yes">Keyboard Shortcuts</attribute>
         <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="true">About Sticky Notes</attribute>
+        <attribute name="label" translatable="yes">About Sticky Notes</attribute>
         <attribute name="action">app.about</attribute>
       </item>
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="true">Quit</attribute>
+        <attribute name="label" translatable="yes">Quit</attribute>
         <attribute name="action">app.quit</attribute>
       </item>
     </section>

--- a/data/ui/theme-selector.ui
+++ b/data/ui/theme-selector.ui
@@ -18,9 +18,9 @@
             <property name="halign">center</property>
             <property name="action-name">app.color-scheme</property>
             <property name="action-target">0</property>
-            <property name="tooltip-text" translatable="true">Follow system style</property>
+            <property name="tooltip-text" translatable="yes">Follow system style</property>
             <accessibility>
-              <property name="label" translatable="true">Follow system style</property>
+              <property name="label" translatable="yes">Follow system style</property>
             </accessibility>
           </object>
         </child>
@@ -35,9 +35,9 @@
             <property name="group">follow</property>
             <property name="action-name">app.color-scheme</property>
             <property name="action-target">1</property>
-            <property name="tooltip-text" translatable="true">Light style</property>
+            <property name="tooltip-text" translatable="yes">Light style</property>
             <accessibility>
-              <property name="label" translatable="true">Light style</property>
+              <property name="label" translatable="yes">Light style</property>
             </accessibility>
           </object>
         </child>
@@ -53,9 +53,9 @@
             <property name="focus-on-click">false</property>
             <property name="action-name">app.color-scheme</property>
             <property name="action-target">4</property>
-            <property name="tooltip-text" translatable="true">Dark style</property>
+            <property name="tooltip-text" translatable="yes">Dark style</property>
             <accessibility>
-              <property name="label" translatable="true">Dark style</property>
+              <property name="label" translatable="yes">Dark style</property>
             </accessibility>
           </object>
         </child>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -20,14 +20,14 @@
               <object class="GtkButton">
                 <property name="icon-name">list-add-symbolic</property>
                 <property name="action-name">app.new-note</property>
-                <property name="tooltip-text" translatable="true">New Note</property>
+                <property name="tooltip-text" translatable="yes">New Note</property>
               </object>
             </child>
             <child type="end">
               <object class="GtkMenuButton" id="menu_button">
                 <property name="icon-name">open-menu-symbolic</property>
                 <property name="menu-model">app_menu</property>
-                <property name="tooltip-text" translatable="true">Main Menu</property>
+                <property name="tooltip-text" translatable="yes">Main Menu</property>
               </object>
             </child>
             <property name="title-widget">
@@ -123,7 +123,7 @@
                     <property name="icon-name">format-text-bold-symbolic</property>
                     <property name="action-name">win.bold</property>
                     <property name="focus-on-click">false</property>
-                    <property name="tooltip-text" translatable="true">Bold</property>
+                    <property name="tooltip-text" translatable="yes">Bold</property>
                   </object>
                 </child>
                 <child>
@@ -131,7 +131,7 @@
                     <property name="icon-name">format-text-italic-symbolic</property>
                     <property name="action-name">win.italic</property>
                     <property name="focus-on-click">false</property>
-                    <property name="tooltip-text" translatable="true">Italic</property>
+                    <property name="tooltip-text" translatable="yes">Italic</property>
                   </object>
                 </child>
                 <child>
@@ -139,7 +139,7 @@
                     <property name="icon-name">format-text-underline-symbolic</property>
                     <property name="action-name">win.underline</property>
                     <property name="focus-on-click">false</property>
-                    <property name="tooltip-text" translatable="true">Underline</property>
+                    <property name="tooltip-text" translatable="yes">Underline</property>
                   </object>
                 </child>
                 <child>
@@ -147,7 +147,7 @@
                     <property name="icon-name">format-text-strikethrough-symbolic</property>
                     <property name="action-name">win.strikethrough</property>
                     <property name="focus-on-click">false</property>
-                    <property name="tooltip-text" translatable="true">Strikethrough</property>
+                    <property name="tooltip-text" translatable="yes">Strikethrough</property>
                   </object>
                 </child>
               </object>
@@ -165,11 +165,11 @@
     </section>
     <section>
       <item>
-        <attribute name="label" translatable="true">All Notes</attribute>
+        <attribute name="label" translatable="yes">All Notes</attribute>
         <attribute name="action">app.all-notes</attribute>
       </item>
       <item>
-        <attribute name="label" translatable="true">Delete Note</attribute>
+        <attribute name="label" translatable="yes">Delete Note</attribute>
         <attribute name="action">win.delete</attribute>
       </item>
     </section>


### PR DESCRIPTION
It appeares that using "yes" is a common practice for translatable strings in GNOME apps.