### PR TITLE
appdata: Use rdns developer ID

### DIFF
--- a/data/com.vixalien.sticky.appdata.xml.in.in
+++ b/data/com.vixalien.sticky.appdata.xml.in.in
@@ -34,7 +34,7 @@
 	<url type="donation">https://www.buymeacoffee.com/vixalien</url>
 	<!-- developer_name tag deprecated with Appstream 1.0 -->
 	<developer_name translatable="no">Angelo Verlain</developer_name>
-  <developer id="github.com">
+  <developer id="com.vixalien">
     <name>Angelo Verlain</name>
   </developer>
 	<update_contact>hey_at_vixalien.com</update_contact>


### PR DESCRIPTION
> A developer tag with a name child tag must be present.
> Only one developer tag is allowed and the name tag also must be present only once in untranslated form.

```
<developer id="tld.vendor">
  <name>Developer name</name>
</developer>
```

More information: https://docs.flathub.org/docs/for-app-authors/metainfo-guidelines/#name-summary-and-developer-name
