### PR TITLE
fix: active if has_tag is 0

### DIFF
--- a/src/view.ts
+++ b/src/view.ts
@@ -260,7 +260,7 @@ class AbstractStickyNote extends Gtk.TextView {
       this.buffer.apply_tag(tag, start, end);
     }
 
-    this.emit("tag-toggle", tag.name, !has_tag);
+    this.emit("tag-toggle", tag.name, has_tag === false);
   }
 
   clear_tags() {


### PR DESCRIPTION
currently, when the selection starts with 0 and the style is unapplied, it still be considered `active`.