### PR TITLE
Add `StartupWMClass` to the desktop file

### DIFF
--- a/data/com.vixalien.sticky.desktop.in.in
+++ b/data/com.vixalien.sticky.desktop.in.in
@@ -3,6 +3,7 @@ Comment=Pin notes to your desktop
 Name=Sticky Notes
 Exec=@app-id@
 Icon=@app-id@
+StartupWMClass=@app-id@
 Terminal=false
 Type=Application
 Categories=GNOME;GTK;Utility;


### PR DESCRIPTION
This should resolve any edge-cases where icon is not shown in Gnome's dash or in other desktop environments, in case there is a regression in compositor recognizing `wmclass` through the desktop filename.

It also respects XDG desktop standards:  
https://specifications.freedesktop.org/desktop-entry-spec/latest/recognized-keys.html