### PR TITLE
feat: add import and export functionality for notes

### DIFF
--- a/data/ui/notes.ui
+++ b/data/ui/notes.ui
@@ -127,6 +127,14 @@
         <attribute name="action">win.show-help-overlay</attribute>
       </item>
       <item>
+        <attribute name="label" translatable="yes">Import Notes…</attribute>
+        <attribute name="action">app.import</attribute>
+      </item>
+      <item>
+        <attribute name="label" translatable="yes">Export All Notes…</attribute>
+        <attribute name="action">app.export</attribute>
+      </item>
+      <item>
         <attribute name="label" translatable="yes">About Sticky Notes</attribute>
         <attribute name="action">app.about</attribute>
       </item>

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -504,3 +504,24 @@ msgstr "Nota vazia"
 
 #~ msgid "First beta release!"
 #~ msgstr "Primeiro lançamento beta!"
+
+#: src/application.ts:552
+msgid "Export Notes"
+msgstr "Exportar notas"
+
+#: src/application.ts:581
+msgid "Failed to Export Notes"
+msgstr "Falha ao exportar notas"
+
+#: src/application.ts:584 src/application.ts:613
+msgid "OK"
+msgstr "OK"
+
+#: src/application.ts:592
+msgid "Import Notes"
+msgstr "Importar notas"
+
+#: src/application.ts:610
+msgid "Failed to Import Notes"
+msgstr "Falha ao importar notas"
+

--- a/src/application.ts
+++ b/src/application.ts
@@ -554,36 +554,34 @@ export class Application extends Adw.Application {
     });
 
     try {
-      const file = await new Promise<Gio.File | null>((resolve, reject) => {
-        dialog.save(this.active_window, null, (obj, res) => {
-          try {
-            resolve(obj!.save_finish(res));
-          } catch (err) {
-            reject(err);
-          }
-        });
-      });
+      const file = await dialog.save(this.active_window, null);
+      if (!file) return;
 
-      if (file) {
-        const notes = this.notes_array();
-        const data = {
-          v: 1,
-          notes: notes.map((n) => n.toJSON()),
-        };
-        const encoder = new TextEncoder();
-        file.replace_contents(
-          encoder.encode(JSON.stringify(data, null, 2)),
-          null,
-          false,
-          Gio.FileCreateFlags.NONE,
-          null,
-        );
-      }
+      const notes = this.notes_array();
+      const data = {
+        v: 1,
+        notes: notes.map((n) => n.toJSON()),
+      };
+      const encoder = new TextEncoder();
+      file.replace_contents(
+        encoder.encode(JSON.stringify(data, null, 2)),
+        null,
+        false,
+        Gio.FileCreateFlags.NONE,
+        null,
+      );
     } catch (err) {
       if (err instanceof GLib.Error && err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED)) {
         return;
       }
       console.error("Failed to export notes:", err);
+      const error_dialog = Adw.MessageDialog.new(
+        this.active_window,
+        _("Failed to Export Notes"),
+        err instanceof Error ? err.message : String(err)
+      );
+      error_dialog.add_response("ok", _("OK"));
+      error_dialog.present();
     }
   }
 
@@ -593,41 +591,40 @@ export class Application extends Adw.Application {
     });
 
     try {
-      const file = await new Promise<Gio.File | null>((resolve, reject) => {
-        dialog.open(this.active_window, null, (obj, res) => {
-          try {
-            resolve(obj!.open_finish(res));
-          } catch (err) {
-            reject(err);
-          }
-        });
-      });
+      const file = await dialog.open(this.active_window, null);
+      if (!file) return;
 
-      if (file) {
-        const [success, contents] = file.load_contents(null);
-        if (success) {
-          const decoder = new TextDecoder();
-          const data = JSON.parse(decoder.decode(contents));
-          if (data.v === 1 && Array.isArray(data.notes)) {
-            data.notes.forEach((noteData: INote) => {
-              // Avoid duplicates by UUID
-              if (!this.find_note(noteData.uuid)) {
-                const note = new Note(noteData);
-                note.connect("notify::modified", () => save_note(note));
-                note.connect("notify::open", () => save_note(note));
-                this.notes_list.append(note);
-                save_note(note);
-              }
-            });
-            this.sort_notes();
-          }
+      const [success, contents] = file.load_contents(null);
+      if (!success) return;
+
+      const decoder = new TextDecoder();
+      const data = JSON.parse(decoder.decode(contents));
+
+      if (data.v !== 1 || !Array.isArray(data.notes)) return;
+
+      data.notes.forEach((noteData: INote) => {
+        // Avoid duplicates by UUID
+        if (!this.find_note(noteData.uuid)) {
+          const note = new Note(noteData);
+          note.connect("notify::modified", () => save_note(note));
+          note.connect("notify::open", () => save_note(note));
+          this.notes_list.append(note);
+          save_note(note);
         }
-      }
+      });
+      this.sort_notes();
     } catch (err) {
       if (err instanceof GLib.Error && err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED)) {
         return;
       }
       console.error("Failed to import notes:", err);
+      const error_dialog = Adw.MessageDialog.new(
+        this.active_window,
+        _("Failed to Import Notes"),
+        err instanceof Error ? err.message : String(err)
+      );
+      error_dialog.add_response("ok", _("OK"));
+      error_dialog.present();
     }
   }
 

--- a/src/application.ts
+++ b/src/application.ts
@@ -31,7 +31,7 @@ import Gtk from "gi://Gtk?version=4.0";
 import Gdk from "gi://Gdk?version=4.0";
 
 import { StickyNotes } from "./notes.js";
-import { Note, settings } from "./util.js";
+import { INote, Note, settings } from "./util.js";
 import {
   delete_note,
   load_notes,
@@ -293,6 +293,14 @@ export class Application extends Adw.Application {
     save.connect("activate", () => this.save());
     this.add_action(save);
 
+    const export_notes = new Gio.SimpleAction({ name: "export" });
+    export_notes.connect("activate", () => this.export_notes());
+    this.add_action(export_notes);
+
+    const import_notes = new Gio.SimpleAction({ name: "import" });
+    import_notes.connect("activate", () => this.import_notes());
+    this.add_action(import_notes);
+
     this.add_action(settings.create_action("color-scheme"));
 
     this.set_accels_for_action("app.quit", ["<Primary>q"]);
@@ -537,6 +545,90 @@ export class Application extends Adw.Application {
     if (note.open === false) note.open = true;
 
     window.present();
+  }
+
+  async export_notes() {
+    const dialog = new Gtk.FileDialog({
+      title: _("Export Notes"),
+      initial_name: "notes.json",
+    });
+
+    try {
+      const file = await new Promise<Gio.File | null>((resolve, reject) => {
+        dialog.save(this.active_window, null, (obj, res) => {
+          try {
+            resolve(obj!.save_finish(res));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      if (file) {
+        const notes = this.notes_array();
+        const data = {
+          v: 1,
+          notes: notes.map((n) => n.toJSON()),
+        };
+        const encoder = new TextEncoder();
+        file.replace_contents(
+          encoder.encode(JSON.stringify(data, null, 2)),
+          null,
+          false,
+          Gio.FileCreateFlags.NONE,
+          null,
+        );
+      }
+    } catch (err) {
+      if (err instanceof GLib.Error && err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED)) {
+        return;
+      }
+      console.error("Failed to export notes:", err);
+    }
+  }
+
+  async import_notes() {
+    const dialog = new Gtk.FileDialog({
+      title: _("Import Notes"),
+    });
+
+    try {
+      const file = await new Promise<Gio.File | null>((resolve, reject) => {
+        dialog.open(this.active_window, null, (obj, res) => {
+          try {
+            resolve(obj!.open_finish(res));
+          } catch (err) {
+            reject(err);
+          }
+        });
+      });
+
+      if (file) {
+        const [success, contents] = file.load_contents(null);
+        if (success) {
+          const decoder = new TextDecoder();
+          const data = JSON.parse(decoder.decode(contents));
+          if (data.v === 1 && Array.isArray(data.notes)) {
+            data.notes.forEach((noteData: INote) => {
+              // Avoid duplicates by UUID
+              if (!this.find_note(noteData.uuid)) {
+                const note = new Note(noteData);
+                note.connect("notify::modified", () => save_note(note));
+                note.connect("notify::open", () => save_note(note));
+                this.notes_list.append(note);
+                save_note(note);
+              }
+            });
+            this.sort_notes();
+          }
+        }
+      }
+    } catch (err) {
+      if (err instanceof GLib.Error && err.matches(Gio.io_error_quark(), Gio.IOErrorEnum.CANCELLED)) {
+        return;
+      }
+      console.error("Failed to import notes:", err);
+    }
   }
 
   vfunc_startup() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,6 +41,9 @@ Gio._promisify(
   "replace_contents_finish",
 );
 
+Gio._promisify(Gtk.FileDialog.prototype, "save", "save_finish");
+Gio._promisify(Gtk.FileDialog.prototype, "open", "open_finish");
+
 export interface ITag {
   name: string;
   start: number;


### PR DESCRIPTION
## Overview
This PR introduces the ability to export and import notes, allowing users to backup their data or migrate notes between different devices.

## Features
- **Export Notes**: Allows users to save all their notes into a single JSON file.
- **Import Notes**: Allows users to restore notes from a previously exported JSON file.
- **Modern UI**: Integrated into the main application menu using the modern `Gtk.FileDialog` for a seamless GNOME experience.

## Technical Details
- Added `export_notes` and `import_notes` actions to `Application`.
- Implemented file selection using the asynchronous `Gtk.FileDialog` (GTK4).
- The exported format is a standard JSON structure containing all note properties (content, style, dimensions, etc.).

## Why this is useful
Currently, there is no easy way for users to backup their notes or move them to a new system. This feature provides data portability and peace of mind for users with a large number of notes.

<img width="676" height="699" alt="image" src="https://github.com/user-attachments/assets/171d89fe-6ab5-4ec9-b9a6-15f7b5952862" />