### PR TITLE
Let notes be given a title

### DIFF
--- a/data/stylus/style-dark.styl
+++ b/data/stylus/style-dark.styl
@@ -14,6 +14,18 @@ toolbarview.note-window {
         color: info.fg_dark;
         background-color: info.header_dark;
       }
+
+      .note-title text {
+        color: info.fg_dark;
+        background-color: info.bg_dark;
+
+        selection:focus-within {
+          background-color: gtkalpha(
+            info.ink,
+            0.3
+          );
+        }
+      }
     }
   }
 }

--- a/data/stylus/style.styl
+++ b/data/stylus/style.styl
@@ -55,6 +55,20 @@ toolbarview.note-window {
         color: info.fg;
         background-color: info.header;
       }
+
+      // the title is edited in place, so the entry it turns into keeps the
+      // colors of the note rather than standing out against its header
+      .note-title text {
+        color: info.fg;
+        background-color: info.bg;
+
+        selection:focus-within {
+          background-color: gtkalpha(
+            info.ink,
+            0.3
+          );
+        }
+      }
     }
   }
 }

--- a/data/ui/card.ui
+++ b/data/ui/card.ui
@@ -17,6 +17,17 @@
           </object>
         </child>
         <child>
+          <object class="GtkLabel" id="title_label">
+            <property name="visible">false</property>
+            <property name="ellipsize">3</property>
+            <property name="max-width-chars">20</property>
+            <property name="xalign">0</property>
+            <style>
+              <class name="caption-heading"/>
+            </style>
+          </object>
+        </child>
+        <child>
           <object class="GtkSeparator">
             <property name="halign">end</property>
             <property name="hexpand">true</property>

--- a/data/ui/help-overlay.ui
+++ b/data/ui/help-overlay.ui
@@ -34,6 +34,12 @@
             </child>
             <child>
               <object class="GtkShortcutsShortcut">
+                <property name="title" translatable="yes" context="shortcut window">Rename Note</property>
+                <property name="action-name">win.rename</property>
+              </object>
+            </child>
+            <child>
+              <object class="GtkShortcutsShortcut">
                 <property name="title" translatable="yes" context="shortcut window">Close Note</property>
                 <property name="action-name">window.close</property>
               </object>

--- a/data/ui/window.ui
+++ b/data/ui/window.ui
@@ -31,7 +31,15 @@
               </object>
             </child>
             <property name="title-widget">
-              <object class="GtkBox"></object>
+              <object class="GtkEditableLabel" id="title_label">
+                <property name="max-width-chars">20</property>
+                <property name="xalign">0.5</property>
+                <property name="tooltip-text" translatable="yes">Note Title</property>
+                <style>
+                  <class name="title" />
+                  <class name="note-title" />
+                </style>
+              </object>
             </property>
             <style>
               <class name="header-bar" />
@@ -134,6 +142,10 @@
       </item>
     </section>
     <section>
+      <item>
+        <attribute name="label" translatable="yes">Rename Note</attribute>
+        <attribute name="action">win.rename</attribute>
+      </item>
       <item>
         <attribute name="label" translatable="yes">All Notes</attribute>
         <attribute name="action">app.all-notes</attribute>

--- a/src/application.ts
+++ b/src/application.ts
@@ -302,6 +302,7 @@ export class Application extends Adw.Application {
     // this.set_accels_for_action("app.cycle-reverse", ["<Primary><Shift>b"]);
     this.set_accels_for_action("app.save", ["<Primary>s"]);
     this.set_accels_for_action("win.delete", ["<Primary>d"]);
+    this.set_accels_for_action("win.rename", ["F2"]);
 
     this.set_accels_for_action("win.open-primary-menu", ["F10"]);
     this.set_accels_for_action("win.show-help-overlay", ["<Primary>question"]);

--- a/src/card.ts
+++ b/src/card.ts
@@ -37,6 +37,7 @@ export class StickyNoteCard extends Gtk.Box {
       Template: "resource:///com/vixalien/sticky/ui/card.ui",
       InternalChildren: [
         "modified_label",
+        "title_label",
         "view_image",
         "delete_button",
         "scrolled",
@@ -58,6 +59,7 @@ export class StickyNoteCard extends Gtk.Box {
 
   declare _scrolled: Gtk.ScrolledWindow;
   declare _modified_label: Gtk.Label;
+  declare _title_label: Gtk.Label;
   declare _view_image: Gtk.Image;
   declare _delete_button: Gtk.Button;
 
@@ -86,7 +88,19 @@ export class StickyNoteCard extends Gtk.Box {
 
     this._note = this.view.note = note;
 
+    this.update_title_label();
     this.update_modified_label();
+  }
+
+  /**
+   * Shows the note's title, but only when it has one of its own: the content
+   * it would otherwise be derived from is right below it in the card.
+   */
+  update_title_label() {
+    const title = this._note?.title;
+
+    this._title_label.label = title ?? "";
+    this._title_label.visible = !!title;
   }
 
   get uuid() {

--- a/src/notes.ts
+++ b/src/notes.ts
@@ -102,6 +102,10 @@ export class StickyNotes extends Adw.ApplicationWindow {
       this.sorter.changed(Gtk.SorterChange.DIFFERENT);
     });
 
+    note.connect("notify::title", () => {
+      card.update_title_label();
+    });
+
     note.connect("notify::open", (_) => {
       card.show_visible_image = note.open;
     });
@@ -146,9 +150,9 @@ export class StickyNotes extends Adw.ApplicationWindow {
 
     const filter = Gtk.CustomFilter.new((note) => {
       const query = this.query;
-      const content = (note as Note).content.toLowerCase();
+      const { title, content } = note as Note;
       if (!query.replace(/\s/g, "")) return true;
-      return content.includes(query);
+      return `${title}\n${content}`.toLowerCase().includes(query);
     });
 
     const filter_model = Gtk.FilterListModel.new(

--- a/src/util.ts
+++ b/src/util.ts
@@ -86,6 +86,17 @@ export const styles = Object.values(Style).filter(
   (style) => typeof style === "number",
 ) as Style[];
 
+/**
+ * The title a note falls back to when it hasn't been given one: the start of
+ * its first line.
+ */
+export const derive_title = (content: string) => {
+  if (!content) return "";
+  let title = content.split("\n")[0].slice(0, 20);
+  if (title.length != content.length) title += "…";
+  return title;
+};
+
 export const settings = new Gio.Settings({ schema_id: "com.vixalien.sticky" });
 
 const get_settings = () => ({
@@ -144,7 +155,16 @@ export class Note extends GObject.Object {
   v: 1;
   uuid: string;
   content: string;
+  /**
+   * The title the note was given, or an empty string when it has none and
+   * follows its content instead. Use `display_title` to show a note's title.
+   */
   title: string;
+  /**
+   * The title as shown to the user: the note's own title, falling back to one
+   * derived from its content. Derived, so never set it directly.
+   */
+  display_title: string;
   style: Style;
   tag_list: Gio.ListStore<Tag>;
   modified: GLib.DateTime;
@@ -195,7 +215,11 @@ export class Note extends GObject.Object {
     this.v = note.v;
     this.uuid = note.uuid;
     this.content = note.content;
-    this.title = note.title;
+    // notes saved before titles could be edited stored the derived title, so
+    // drop those: they are meant to keep following the content
+    const title = note.title ?? "";
+    this.title = title === derive_title(note.content) ? "" : title;
+    this.display_title = this.title || derive_title(this.content);
     this.style = note.style;
     this.tag_list = Gio.ListStore.new(Tag.$gtype) as Gio.ListStore<Tag>;
     this.tags = note.tags;
@@ -207,21 +231,14 @@ export class Note extends GObject.Object {
     this.height = note.height;
     this.open = note.open ?? false;
 
-    this.bind_property_full(
-      "content",
-      this,
-      "title",
-      GObject.BindingFlags.SYNC_CREATE,
-      (_, content) => {
-        if (!content) return [true, ""];
-        let title = content.split("\n")[0].slice(0, 20);
-        if (title.length != content.length) title += "…";
-        return [true, title];
-      },
-      null
-    );
+    const update_display_title = () => {
+      const display_title = this.title || derive_title(this.content);
+      if (display_title === this.display_title) return;
+      this.display_title = display_title;
+    };
 
-
+    this.connect("notify::title", update_display_title);
+    this.connect("notify::content", update_display_title);
   }
 
   static generate() {
@@ -285,6 +302,8 @@ export class Note extends GObject.Object {
         content: GObject.ParamSpec.string("content", "Content", "Content of the note", GObject.ParamFlags.READWRITE, ""),
         // deno-fmt-ignore
         title: GObject.ParamSpec.string("title", "Title", "Title of the note", GObject.ParamFlags.READWRITE, ""),
+        // deno-fmt-ignore
+        display_title: GObject.ParamSpec.string("display-title", "Display Title", "Title of the note, or one derived from its content", GObject.ParamFlags.READWRITE, ""),
         // deno-fmt-ignore
         style: GObject.ParamSpec.int("style", "Style", "Style of the note", GObject.ParamFlags.READWRITE, 0, 100, 0),
         // deno-fmt-ignore

--- a/src/window.ts
+++ b/src/window.ts
@@ -39,6 +39,7 @@ export class Window extends Adw.ApplicationWindow {
   declare _container: Gtk.Box;
   declare _text: Gtk.TextView;
   declare _menu_button: Gtk.MenuButton;
+  declare _title_label: Gtk.EditableLabel;
 
   declare _bold_button: Gtk.ToggleButton;
   declare _underline_button: Gtk.ToggleButton;
@@ -64,6 +65,7 @@ export class Window extends Adw.ApplicationWindow {
         InternalChildren: [
           "container",
           "text",
+          "title_label",
           "bold_button",
           "underline_button",
           "italic_button",
@@ -99,7 +101,7 @@ export class Window extends Adw.ApplicationWindow {
     this.default_height = note.height;
 
     this.note.bind_property_full(
-      "title",
+      "display-title",
       this,
       "title",
       GObject.BindingFlags.SYNC_CREATE,
@@ -112,10 +114,28 @@ export class Window extends Adw.ApplicationWindow {
       null,
     );
 
+    // the label shows the same title as the window, so that a note that
+    // hasn't been given one still has something to click on to give it one
+    this.bind_property(
+      "title",
+      this._title_label,
+      "text",
+      GObject.BindingFlags.SYNC_CREATE,
+    );
+
+    this._title_label.connect("notify::editing", () => {
+      if (this._title_label.editing) return;
+      this.rename(this._title_label.text);
+    });
+
     this.connect("close-request", () => {
       if (this.deleted) return;
 
-      if (this.view.note && this.view.note.content.trim().length === 0) {
+      // a note that was given a title is worth keeping even while it is empty
+      if (
+        this.view.note && this.view.note.content.trim().length === 0 &&
+        !this.note.title
+      ) {
         (this.application as Application).delete_note(this.note.uuid);
         return;
       }
@@ -163,6 +183,31 @@ export class Window extends Adw.ApplicationWindow {
 
     const popover = this._menu_button.get_popover() as Gtk.PopoverMenu;
     popover.add_child(this.selector, "notestyleswitcher");
+  }
+
+  /**
+   * The title shown in the header bar and the window manager, which is the
+   * note's own title when it has one, and one derived from its content
+   * otherwise.
+   */
+  get display_title() {
+    return this.note.display_title || _("Sticky Note");
+  }
+
+  /**
+   * Gives the note the title left in the header bar, or takes its title away
+   * when the label was emptied, letting it follow the content again.
+   *
+   * The label shows the derived title of an untitled note, so text that was
+   * left as it was found means the note keeps having no title of its own.
+   */
+  rename(text: string) {
+    const title = text.trim();
+
+    if (title === this.display_title) return;
+
+    this.note.title = title;
+    this.note.modified_date = new Date();
   }
 
   last_revealer = false;
@@ -220,6 +265,10 @@ export class Window extends Adw.ApplicationWindow {
     const delete_ = Gio.SimpleAction.new("delete", null);
     delete_.connect("activate", () => this.delete());
     this.add_action(delete_);
+
+    const rename = Gio.SimpleAction.new("rename", null);
+    rename.connect("activate", () => this._title_label.start_editing());
+    this.add_action(rename);
 
     for (const [name, tag] of this.view.actions) {
       const action = Gio.SimpleAction.new(name, null);


### PR DESCRIPTION
A note's title was a read-only mirror of the start of its content. It can now be one the user writes, while notes without one keep following their content exactly as before.

The header bar of a note, which held an empty placeholder, now shows the title in an editable label: click it to edit, Enter commits and Escape cancels. Emptying the label takes the title away again, so the note goes back to following its content. The same editing is reachable from a "Rename Note" menu item and from F2.

Since the label shows the fallback title of an untitled note, text that was left as it was found never becomes a title of its own. A note that was given a title is no longer deleted on close while it is empty.

The All Notes window shows a note's title, but only when it has one of its own: the content it would otherwise be derived from is right below it in the card. Search matches titles as well as content.

Notes saved before this stored the derived title, so those are dropped on load, and keep following their content rather than freezing a stale snippet of it as a title.