### PR TITLE
Keep the text cursor visible while editing notes

### DIFF
--- a/src/window.ts
+++ b/src/window.ts
@@ -152,9 +152,7 @@ export class Window extends Adw.ApplicationWindow {
     });
 
     this._text.buffer = this.view.buffer;
-    this.view.buffer.connect_after("mark-set", (_buffer, _loc, mark) => {
-      if (mark.name !== "insert") return;
-
+    this.view.buffer.connect("notify::cursor-position", (buffer) => {
       const height = this._text.get_allocated_height();
       if (height <= 0) return;
 
@@ -162,7 +160,7 @@ export class Window extends Adw.ApplicationWindow {
         0.49,
         Math.max(this._text.top_margin, this._text.bottom_margin) / height,
       );
-      this._text.scroll_to_mark(mark, margin, false, 0, 0);
+      this._text.scroll_to_mark(buffer.get_insert(), margin, false, 0, 0);
     });
 
     this.add_actions();

--- a/src/window.ts
+++ b/src/window.ts
@@ -152,6 +152,19 @@ export class Window extends Adw.ApplicationWindow {
     });
 
     this._text.buffer = this.view.buffer;
+    this.view.buffer.connect_after("insert-text", (buffer, _loc, text) => {
+      if (text !== "\n") return;
+
+      const insert = buffer.get_insert();
+      const cursor = buffer.get_iter_at_mark(insert);
+      if (cursor.get_line() !== buffer.get_line_count() - 1) return;
+
+      GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
+        const adjustment = this._text.vadjustment;
+        adjustment.value = adjustment.upper - adjustment.page_size;
+        return GLib.SOURCE_REMOVE;
+      });
+    });
 
     this.add_actions();
 

--- a/src/window.ts
+++ b/src/window.ts
@@ -55,6 +55,7 @@ export class Window extends Adw.ApplicationWindow {
 
   note: Note;
   deleted = false;
+  cursor_scroll_source: number | null = null;
 
   static {
     GObject.registerClass(
@@ -152,16 +153,11 @@ export class Window extends Adw.ApplicationWindow {
     });
 
     this._text.buffer = this.view.buffer;
-    this.view.buffer.connect("notify::cursor-position", (buffer) => {
-      const height = this._text.get_allocated_height();
-      if (height <= 0) return;
-
-      const margin = Math.min(
-        0.49,
-        Math.max(this._text.top_margin, this._text.bottom_margin) / height,
-      );
-      this._text.scroll_to_mark(buffer.get_insert(), margin, false, 0, 0);
-    });
+    this.view.buffer.connect(
+      "notify::cursor-position",
+      this.queue_cursor_scroll.bind(this),
+    );
+    this.view.buffer.connect("changed", this.queue_cursor_scroll.bind(this));
 
     this.add_actions();
 
@@ -173,6 +169,40 @@ export class Window extends Adw.ApplicationWindow {
 
     const popover = this._menu_button.get_popover() as Gtk.PopoverMenu;
     popover.add_child(this.selector, "notestyleswitcher");
+  }
+
+  queue_cursor_scroll() {
+    if (this.cursor_scroll_source !== null) return;
+
+    this.cursor_scroll_source = GLib.idle_add(
+      GLib.PRIORITY_DEFAULT_IDLE,
+      () => {
+        this.cursor_scroll_source = null;
+        this.scroll_cursor_into_view();
+        return GLib.SOURCE_REMOVE;
+      },
+    );
+  }
+
+  scroll_cursor_into_view() {
+    const cursor = this.view.buffer.get_iter_at_mark(
+      this.view.buffer.get_insert(),
+    );
+    const cursor_rect = this._text.get_iter_location(cursor);
+    const visible_rect = this._text.get_visible_rect();
+    const visible_top = visible_rect.y + this._text.top_margin;
+    const visible_bottom = visible_rect.y + visible_rect.height -
+      this._text.bottom_margin;
+
+    let offset = 0;
+    if (cursor_rect.y < visible_top) {
+      offset = cursor_rect.y - visible_top;
+    } else if (cursor_rect.y + cursor_rect.height > visible_bottom) {
+      offset = cursor_rect.y + cursor_rect.height - visible_bottom;
+    }
+
+    if (offset === 0) return;
+    this._text.vadjustment.value += offset;
   }
 
   last_revealer = false;

--- a/src/window.ts
+++ b/src/window.ts
@@ -56,6 +56,7 @@ export class Window extends Adw.ApplicationWindow {
   note: Note;
   deleted = false;
   cursor_scroll_source: number | null = null;
+  last_revealer = false;
 
   static {
     GObject.registerClass(
@@ -114,6 +115,8 @@ export class Window extends Adw.ApplicationWindow {
     );
 
     this.connect("close-request", () => {
+      this.cancel_cursor_scroll();
+
       if (this.deleted) return;
 
       if (this.view.note && this.view.note.content.trim().length === 0) {
@@ -131,6 +134,7 @@ export class Window extends Adw.ApplicationWindow {
         this.note.height = height;
       }
     });
+    this.connect("unrealize", this.cancel_cursor_scroll.bind(this));
 
     this.set_style(note.style, true);
 
@@ -172,7 +176,7 @@ export class Window extends Adw.ApplicationWindow {
   }
 
   queue_cursor_scroll() {
-    if (this.cursor_scroll_source !== null) return;
+    if (!this.get_realized() || this.cursor_scroll_source !== null) return;
 
     this.cursor_scroll_source = GLib.idle_add(
       GLib.PRIORITY_DEFAULT_IDLE,
@@ -182,6 +186,13 @@ export class Window extends Adw.ApplicationWindow {
         return GLib.SOURCE_REMOVE;
       },
     );
+  }
+
+  cancel_cursor_scroll() {
+    if (this.cursor_scroll_source === null) return;
+
+    GLib.source_remove(this.cursor_scroll_source);
+    this.cursor_scroll_source = null;
   }
 
   scroll_cursor_into_view() {
@@ -205,12 +216,14 @@ export class Window extends Adw.ApplicationWindow {
     this._text.vadjustment.value += offset;
   }
 
-  last_revealer = false;
-
   update_link(selected: boolean, text: string) {
     if (selected) {
-      const href = find(text)[0].href;
-      this._action_button.action_target = GLib.Variant.new_string(href);
+      const link = find(text)[0];
+      if (link) {
+        this._action_button.action_target = GLib.Variant.new_string(link.href);
+      } else {
+        selected = false;
+      }
     }
 
     if (this.last_revealer === selected) return;

--- a/src/window.ts
+++ b/src/window.ts
@@ -152,18 +152,17 @@ export class Window extends Adw.ApplicationWindow {
     });
 
     this._text.buffer = this.view.buffer;
-    this.view.buffer.connect_after("insert-text", (buffer, _loc, text) => {
-      if (text !== "\n") return;
+    this.view.buffer.connect_after("mark-set", (_buffer, _loc, mark) => {
+      if (mark.name !== "insert") return;
 
-      const insert = buffer.get_insert();
-      const cursor = buffer.get_iter_at_mark(insert);
-      if (cursor.get_line() !== buffer.get_line_count() - 1) return;
+      const height = this._text.get_allocated_height();
+      if (height <= 0) return;
 
-      GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-        const adjustment = this._text.vadjustment;
-        adjustment.value = adjustment.upper - adjustment.page_size;
-        return GLib.SOURCE_REMOVE;
-      });
+      const margin = Math.min(
+        0.49,
+        Math.max(this._text.top_margin, this._text.bottom_margin) / height,
+      );
+      this._text.scroll_to_mark(mark, margin, false, 0, 0);
     });
 
     this.add_actions();


### PR DESCRIPTION
  ## Summary
- Keep the active text cursor visible while typing or navigating through long notes.
- Scrolling is deferred until GTK finishes text layout, then the cursor position is checked against the visible area excluding the overlaid toolbars. The view scrolls only as far as
  necessary.